### PR TITLE
Add padding to #root for safe area insets

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -1,3 +1,7 @@
+#root {
+   padding-bottom: calc(var(--tg-safe-area-inset-bottom) + var(--tg-content-safe-area-inset-bottom)); 
+}
+
 html, body, #root, #root>div {
     margin: 0;
     min-height: 100%;


### PR DESCRIPTION
This pull request fixes a cosmetic issue where the root element was missing some padding from the bottom of the screen.

| Before | After |
| ------- | ----- |
| <img width="295" height="640" alt="image" src="https://github.com/user-attachments/assets/ec03a142-143f-4d05-88aa-37b84ca84946" /> | <img width="295" height="640" alt="image" src="https://github.com/user-attachments/assets/bde728ea-9829-452e-820a-8cbdd2a8543c" /> |